### PR TITLE
fix terraform error msg validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "enforce_group_id" {
 
   validation {
     condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
-    error_message = "enforce_group_id must be a valid group id"
+    error_message = "The enforce_group_id must be a valid group id."
   }
 }
 


### PR DESCRIPTION
 Error: Invalid validation error message
│ 
│   on .terraform/modules/dogfood.impersonation/variables.tf line 17, in variable "enforce_group_id":
│   17:     error_message = "enforce_group_id must be a valid group id"
│ 
│ The validation error message must be at least one full sentence starting with an uppercase letter and ending with a period or question mark.
│ 
│ Your given message will be included as part of a larger Terraform error message, written as English prose. For broadly-shared modules we suggest using a similar writing style so that the overall result will be consistent.


Signed-off-by: Kenny Leung <kleung@chainguard.dev>