### PR TITLE
support list of enforce group ids to associate with google project 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ No requirements.
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -104,6 +105,7 @@ No modules.
 | [google_service_account_iam_binding.allow_cosigned_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_binding.allow_discovery_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_binding.allow_signer_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [null_resource.enforce_group_id_is_specified](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_project.provider_default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
@@ -111,7 +113,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | DEPRECATED: Please use 'enforce\_group\_ids'. Enforce IAM group ID to bind your AWS account to | `string` | n/a | yes |
+| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | DEPRECATED: Please use 'enforce\_group\_ids'. Enforce IAM group ID to bind your AWS account to | `string` | `""` | no |
 | <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to. If both 'enforce\_group\_id' and 'enforce\_group\_ids' are specified, 'enforce\_group\_id' is ignored. | `list(string)` | `[]` | no |
 | <a name="input_google_project_id"></a> [google\_project\_id](#input\_google\_project\_id) | GCP Project ID. If not set, will default to provider default project id | `string` | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or using our (soon to be released publically) Terraform provider
 
 ```Terraform
 resource "chainguard_account_associations" "example" {
-  group = ["<< enforce group id>>"]
+  group = "<< enforce group id>>"
   google {
     project_id     = "<< project id >>"
     project_number = "<< project number >>"
@@ -43,7 +43,7 @@ To configured the connection on AWS side use this module as follows:
 module "chainguard-account-association" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
-  enforce_group_ids = ["<< enforce group id >>"]
+  enforce_group_id = "<< enforce group id >>"
 }
 ```
 
@@ -72,8 +72,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.43.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 4.43.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To configured the connection on AWS side use this module as follows:
 module "chainguard-account-association" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
-  enforce_group_id = "<< enforce group id>>"
+  enforce_group_ids = ["<< enforce group id >>"]
 }
 ```
 
@@ -111,7 +111,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | Enforce IAM group ID to bind your AWS account to | `string` | n/a | yes |
+| <a name="input_enforce_group_ids"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | Enforce IAM group IDs to bind your Google AWS account to | `list(string)` | n/a | yes |
 | <a name="input_google_project_id"></a> [google\_project\_id](#input\_google\_project\_id) | GCP Project ID. If not set, will default to provider default project id | `string` | `""` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to | `list(string)` | n/a | yes |
+| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | DEPRECATED: Please use 'enforce\_group\_ids'. Enforce IAM group ID to bind your AWS account to | `string` | n/a | yes |
+| <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to. If both 'enforce\_group\_id' and 'enforce\_group\_ids' are specified, 'enforce\_group\_id' is ignored. | `list(string)` | `[]` | no |
 | <a name="input_google_project_id"></a> [google\_project\_id](#input\_google\_project\_id) | GCP Project ID. If not set, will default to provider default project id | `string` | `""` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | n/a |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.43.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 4.43.0 |
 
 ## Modules
 
@@ -111,7 +111,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_ids"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | Enforce IAM group IDs to bind your Google AWS account to | `list(string)` | n/a | yes |
+| <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to | `list(string)` | n/a | yes |
 | <a name="input_google_project_id"></a> [google\_project\_id](#input\_google\_project\_id) | GCP Project ID. If not set, will default to provider default project id | `string` | `""` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or using our (soon to be released publically) Terraform provider
 
 ```Terraform
 resource "chainguard_account_associations" "example" {
-  group = "<< enforce group id>>"
+  group = ["<< enforce group id>>"]
   google {
     project_id     = "<< project id >>"
     project_number = "<< project number >>"

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ No modules.
 | [google_service_account.chainguard_cosigned](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.chainguard_discovery](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.chainguard_signer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_member.allow_agentless_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_service_account_iam_member.allow_canary_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_service_account_iam_member.allow_cosigned_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_service_account_iam_member.allow_discovery_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_service_account_iam_member.allow_signer_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_binding.allow_agentless_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.allow_canary_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.allow_cosigned_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.allow_discovery_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.allow_signer_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_project.provider_default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/agentless.tf
+++ b/agentless.tf
@@ -8,9 +8,11 @@ resource "google_service_account" "chainguard_agentless" {
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
 resource "google_service_account_iam_member" "allow_agentless_impersonation" {
+  for_each = toset(var.enforce_group_ids)
+
   service_account_id = google_service_account.chainguard_agentless.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/agentless:${var.enforce_group_id}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/agentless:${each.value}"
 }
 
 // Grant the service account permissions to access the resources it

--- a/agentless.tf
+++ b/agentless.tf
@@ -8,7 +8,7 @@ resource "google_service_account" "chainguard_agentless" {
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
 resource "google_service_account_iam_member" "allow_agentless_impersonation" {
-  for_each = toset(var.enforce_group_ids)
+  for_each = toset(local.enforce_group_ids)
 
   service_account_id = google_service_account.chainguard_agentless.name
   role               = "roles/iam.workloadIdentityUser"

--- a/agentless.tf
+++ b/agentless.tf
@@ -7,12 +7,10 @@ resource "google_service_account" "chainguard_agentless" {
 
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
-resource "google_service_account_iam_member" "allow_agentless_impersonation" {
-  for_each = toset(local.enforce_group_ids)
-
+resource "google_service_account_iam_binding" "allow_agentless_impersonation" {
   service_account_id = google_service_account.chainguard_agentless.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/agentless:${each.value}"
+  members            = [for id in local.enforce_group_ids : "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/agentless:${id}"]
 }
 
 // Grant the service account permissions to access the resources it

--- a/canary.tf
+++ b/canary.tf
@@ -7,10 +7,8 @@ resource "google_service_account" "chainguard_canary" {
 
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
-resource "google_service_account_iam_member" "allow_canary_impersonation" {
-  for_each = toset(local.enforce_group_ids)
-
+resource "google_service_account_iam_binding" "allow_canary_impersonation" {
   service_account_id = google_service_account.chainguard_canary.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/canary:${each.value}"
+  members            = [for id in local.enforce_group_ids : "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/canary:${id}"]
 }

--- a/canary.tf
+++ b/canary.tf
@@ -8,7 +8,9 @@ resource "google_service_account" "chainguard_canary" {
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
 resource "google_service_account_iam_member" "allow_canary_impersonation" {
+  for_each = toset(var.enforce_group_ids)
+
   service_account_id = google_service_account.chainguard_canary.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/canary:${var.enforce_group_id}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/canary:${each.value}"
 }

--- a/canary.tf
+++ b/canary.tf
@@ -8,7 +8,7 @@ resource "google_service_account" "chainguard_canary" {
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
 resource "google_service_account_iam_member" "allow_canary_impersonation" {
-  for_each = toset(var.enforce_group_ids)
+  for_each = toset(local.enforce_group_ids)
 
   service_account_id = google_service_account.chainguard_canary.name
   role               = "roles/iam.workloadIdentityUser"

--- a/cosigned.tf
+++ b/cosigned.tf
@@ -8,7 +8,7 @@ resource "google_service_account" "chainguard_cosigned" {
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
 resource "google_service_account_iam_member" "allow_cosigned_impersonation" {
-  for_each = toset(var.enforce_group_ids)
+  for_each = toset(local.enforce_group_ids)
 
   service_account_id = google_service_account.chainguard_cosigned.name
   role               = "roles/iam.workloadIdentityUser"

--- a/cosigned.tf
+++ b/cosigned.tf
@@ -8,9 +8,11 @@ resource "google_service_account" "chainguard_cosigned" {
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
 resource "google_service_account_iam_member" "allow_cosigned_impersonation" {
+  for_each = toset(var.enforce_group_ids)
+
   service_account_id = google_service_account.chainguard_cosigned.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/cosigned:${var.enforce_group_id}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/cosigned:${each.value}"
 }
 
 // Grant the service account permissions to access the resources it

--- a/cosigned.tf
+++ b/cosigned.tf
@@ -7,12 +7,10 @@ resource "google_service_account" "chainguard_cosigned" {
 
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
-resource "google_service_account_iam_member" "allow_cosigned_impersonation" {
-  for_each = toset(local.enforce_group_ids)
-
+resource "google_service_account_iam_binding" "allow_cosigned_impersonation" {
   service_account_id = google_service_account.chainguard_cosigned.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/cosigned:${each.value}"
+  members            = [for id in local.enforce_group_ids : "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/cosigned:${id}"]
 }
 
 // Grant the service account permissions to access the resources it

--- a/discovery.tf
+++ b/discovery.tf
@@ -7,10 +7,10 @@ resource "google_service_account" "chainguard_discovery" {
 
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
-resource "google_service_account_iam_member" "allow_discovery_impersonation" {
+resource "google_service_account_iam_binding" "allow_discovery_impersonation" {
   service_account_id = google_service_account.chainguard_discovery.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/discovery:${var.enforce_group_id}"
+  members            = [for id in local.enforce_group_ids : "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/discovery:${id}"]
 }
 
 // Grant the service account permissions to access the resources it

--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -7,10 +7,10 @@ resource "google_service_account" "chainguard_signer" {
 
 // Allow the provider (mapped token) to impersonate this service account if
 // the subject matches what we expect.
-resource "google_service_account_iam_member" "allow_signer_impersonation" {
+resource "google_service_account_iam_binding" "allow_signer_impersonation" {
   service_account_id = google_service_account.chainguard_signer.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/enforce-signer:${var.enforce_group_id}"
+  members            = [for id in local.enforce_group_ids : "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/enforce-signer:${id}"]
 }
 
 // TODO(hectorj2f) Think about restricting cloudkms.cryptoKeyEncrypterDecrypter permissions to a keyring, e.g. key_ring_id = google_kms_key_ring.sigstore-keyring.id

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     chainguard = {
       # NB: This provider is currently not public
-      source = "chainguard-dev/chainguard"
+      source = "chainguard/chainguard"
     }
   }
 }
@@ -34,13 +34,13 @@ module "account_association" {
 
   google_project_id   = data.google_project.current.project_id
   enforce_domain_name = "chainguard.dev"
-  enforce_group_ids   = [chainguard_group.root.id]
+  enforce_group_id    = chainguard_group.root.id
 }
 
 resource "chainguard_account_associations" "demo-chaingaurd-dev-binding" {
   group = chainguard_group.root.id
   google {
     project_id   = data.google_project.current.project_id
-    project_name = data.google_project.current.project_name
+    project_number = data.google_project.current.number
   }
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -34,7 +34,7 @@ module "account_association" {
 
   google_project_id   = data.google_project.current.project_id
   enforce_domain_name = "chainguard.dev"
-  enforce_group_id    = chainguard_group.root.id
+  enforce_group_ids    = [chainguard_group.root.id]
 }
 
 resource "chainguard_account_associations" "demo-chaingaurd-dev-binding" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -34,7 +34,7 @@ module "account_association" {
 
   google_project_id   = data.google_project.current.project_id
   enforce_domain_name = "chainguard.dev"
-  enforce_group_ids    = [chainguard_group.root.id]
+  enforce_group_ids   = [chainguard_group.root.id]
 }
 
 resource "chainguard_account_associations" "demo-chaingaurd-dev-binding" {

--- a/examples/multiple-group-ids/main.tf
+++ b/examples/multiple-group-ids/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    chainguard = {
+      # NB: This provider is currently not public
+      source = "chainguard/chainguard"
+    }
+  }
+}
+
+provider "chainguard" {
+  console_api = "https://console-api.chainguard.dev"
+}
+
+provider "google" {}
+
+provider "google-beta" {}
+
+data "google_project" "current" {
+}
+
+resource "chainguard_group" "root" {
+  name        = "demo root"
+  description = "root group for demo"
+}
+
+module "account_association" {
+  source = "./../../"
+
+  google_project_id   = data.google_project.current.project_id
+  enforce_domain_name = "chainguard.dev"
+  enforce_group_id    = chainguard_group.root.id
+  enforce_group_ids   = [chainguard_group.root.id, "000000"]
+}
+
+resource "chainguard_account_associations" "demo-chaingaurd-dev-binding" {
+  group = chainguard_group.root.id
+  google {
+    project_id     = data.google_project.current.project_id
+    project_number = data.google_project.current.number
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,8 @@ data "google_project" "provider_default" {
 }
 
 locals {
-  project_id = var.google_project_id == "" ? data.google_project.provider_default.project_id : var.google_project_id
+  project_id        = var.google_project_id == "" ? data.google_project.provider_default.project_id : var.google_project_id
+  enforce_group_ids = length(var.enforce_group_ids) > 0 ? var.enforce_group_ids : [var.enforce_group_id]
 }
 
 // Providers define the scopes at which Chainguard services may impersonate

--- a/variables.tf
+++ b/variables.tf
@@ -6,15 +6,19 @@ variable "enforce_domain_name" {
   nullable    = false
 }
 
-variable "enforce_group_id" {
-  type        = string
-  description = "Enforce IAM group ID to bind your AWS account to"
+variable "enforce_group_ids" {
+  type        = list(string)
+  description = "Enforce IAM group IDs to bind your AWS account to"
   sensitive   = false
   nullable    = false
 
   validation {
-    condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
-    error_message = "The enforce_group_id must be a valid group id."
+    condition     = length(var.enforce_group_ids) > 0
+    error_message = "Must provide at least one id to enforce_group_ids."
+  }
+  validation {
+    condition     = can([for g in var.enforce_group_ids : regex("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", g)])
+    error_message = "IDs in enforce_group_ids must be a valid group id."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,8 @@ variable "enforce_domain_name" {
 variable "enforce_group_id" {
   type        = string
   description = "DEPRECATED: Please use 'enforce_group_ids'. Enforce IAM group ID to bind your AWS account to"
+  default     = ""
   sensitive   = false
-  nullable    = false
 
   validation {
     condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
@@ -36,4 +36,13 @@ variable "google_project_id" {
   description = "GCP Project ID. If not set, will default to provider default project id"
   sensitive   = false
   nullable    = false
+}
+
+resource "null_resource" "enforce_group_id_is_specified" {
+  lifecycle {
+    precondition {
+      condition     = length(var.enforce_group_ids) > 0 || var.enforce_group_id != ""
+      error_message = "one of variable [enforce_group_id, enforce_group_ids] must be specified."
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,6 @@ variable "enforce_domain_name" {
   nullable    = false
 }
 
-
 variable "enforce_group_id" {
   type        = string
   description = "DEPRECATED: Please use 'enforce_group_ids'. Enforce IAM group ID to bind your AWS account to"

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,6 @@ variable "enforce_group_ids" {
   default     = []
 
   validation {
-    condition     = length(var.enforce_group_ids) > 0
-    error_message = "Must provide at least one id to enforce_group_ids."
-  }
-  validation {
     condition     = can([for g in var.enforce_group_ids : regex("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", g)])
     error_message = "IDs in enforce_group_ids must be a valid group id."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,24 @@ variable "enforce_domain_name" {
   nullable    = false
 }
 
-variable "enforce_group_ids" {
-  type        = list(string)
-  description = "Enforce IAM group IDs to bind your AWS account to"
+
+variable "enforce_group_id" {
+  type        = string
+  description = "DEPRECATED: Please use 'enforce_group_ids'. Enforce IAM group ID to bind your AWS account to"
   sensitive   = false
   nullable    = false
+
+  validation {
+    condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
+    error_message = "The value 'enforce_group_id' must be a valid group id."
+  }
+}
+
+variable "enforce_group_ids" {
+  type        = list(string)
+  description = "Enforce IAM group IDs to bind your AWS account to. If both 'enforce_group_id' and 'enforce_group_ids' are specified, 'enforce_group_id' is ignored."
+  sensitive   = false
+  default     = []
 
   validation {
     condition     = length(var.enforce_group_ids) > 0


### PR DESCRIPTION
Rather than only supporting the association of a single enforce group id, support multiple group ids, as a list.

Toward addressing https://github.com/chainguard-dev/customer-issues/issues/66

Signed-off-by: Kenny Leung <kleung@chainguard.dev>