### PR TITLE
enforce-signer: create custom role

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ to bind to certain IAM roles. In particular it allows:
 This access is restricted to clusters and policies you've configured at or
 below the scope of the Enforce group you configure.
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -117,3 +118,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_provider_id"></a> [provider\_id](#output\_provider\_id) | GCP identity provider pool configured for Enforce |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ to bind to certain IAM roles. In particular it allows:
 This access is restricted to clusters and policies you've configured at or
 below the scope of the Enforce group you configure.
 
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -85,13 +84,13 @@ No modules.
 |------|------|
 | [google-beta_google_iam_workload_identity_pool.chainguard_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool) | resource |
 | [google-beta_google_iam_workload_identity_pool_provider.chainguard_provider](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool_provider) | resource |
+| [google_project_iam_custom_role.chainguard_signer_ca_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_member.agentless_gke_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cosigned_gcr_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cosigned_kms_pki_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cosigned_kms_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.discovery_cluster_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.signer_cert_requester](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.signer_encrypt_decrypter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.signer_certificate_authorities](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.iamcredentials-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_service_account.chainguard_agentless](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.chainguard_canary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
@@ -118,4 +117,3 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_provider_id"></a> [provider\_id](#output\_provider\_id) | GCP identity provider pool configured for Enforce |
-<!-- END_TF_DOCS -->

--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -13,15 +13,22 @@ resource "google_service_account_iam_member" "allow_signer_impersonation" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/enforce-signer:${var.enforce_group_id}"
 }
 
-resource "google_project_iam_member" "signer_cert_requester" {
-  project = local.project_id
-  role    = "roles/privateca.certificateRequester"
-  member  = "serviceAccount:${google_service_account.chainguard_signer.email}"
+// TODO(hectorj2f) Think about restricting cloudkms.cryptoKeyEncrypterDecrypter permissions to a keyring, e.g. key_ring_id = google_kms_key_ring.sigstore-keyring.id
+resource "google_project_iam_custom_role" "chainguard_signer_ca_role" {
+  project     = local.project_id
+  role_id     = "chainguardSignerCA"
+  title       = "Custom Role Chainguard Signer CA"
+  description = "Chainguard signer role to list certificates from a CA"
+  permissions = [
+    "privateca.certificateAuthorities.list",
+    "privateca.certificateAuthorities.get",
+    "privateca.certificates.create",
+    "cloudkms.cryptoKeyEncrypterDecrypter",
+  ]
 }
 
-// TODO(hectorj2f) Think about restricting this access to a keyring, e.g. key_ring_id = google_kms_key_ring.sigstore-keyring.id
-resource "google_project_iam_member" "signer_encrypt_decrypter" {
+resource "google_project_iam_member" "signer_certificate_authorities" {
   project = local.project_id
-  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  role    = "projects/${local.project_id}/roles/${google_project_iam_custom_role.chainguard_signer_ca_role.role_id}"
   member  = "serviceAccount:${google_service_account.chainguard_signer.email}"
 }


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

We must create a custom role to scope the required permission down to what we need.