### PR TITLE
Feature: Integrate with GCP audit logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,22 @@ No modules.
 |------|------|
 | [google-beta_google_iam_workload_identity_pool.chainguard_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool) | resource |
 | [google-beta_google_iam_workload_identity_pool_provider.chainguard_provider](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool_provider) | resource |
+| [google_logging_project_sink.gcp_auditlog_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_project_iam_custom_role.chainguard_signer_ca_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.create_auditlog_subscriptions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_member.agentless_gke_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cosigned_gcr_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cosigned_kms_pki_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cosigned_kms_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.discover_auditlog_subscriber](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.discovery_cluster_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.discovery_run_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.ingester_gcr_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.signer_certificate_authorities](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.iamcredentials-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_pubsub_topic.gcp_auditlog_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_member.publisher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
+| [google_pubsub_topic_iam_member.subscriber](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
 | [google_service_account.chainguard_agentless](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.chainguard_canary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.chainguard_cosigned](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |

--- a/discovery.tf
+++ b/discovery.tf
@@ -13,8 +13,13 @@ resource "google_service_account_iam_binding" "allow_discovery_impersonation" {
   members            = [for id in local.enforce_group_ids : "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.chainguard_pool.name}/attribute.sub/discovery:${id}"]
 }
 
+///////////////////////////////////////////////////////////////////////////
+//
 // Grant the service account permissions to access the resources it
-// needs to fulfill its purpose.
+// needs to fulfill its purpose.  Any new service that is added here
+// should also be added to the audit log filter below.
+//
+///////////////////////////////////////////////////////////////////////////
 resource "google_project_iam_member" "discovery_cluster_viewer" {
   project = local.project_id
   role    = "roles/container.clusterViewer"
@@ -25,4 +30,71 @@ resource "google_project_iam_member" "discovery_run_viewer" {
   project = local.project_id
   role    = "roles/run.viewer"
   member  = "serviceAccount:${google_service_account.chainguard_discovery.email}"
+}
+
+
+///////////////////////////////////////////////////////////////////////////
+//
+// Configure a pubsub topic audit log sink, so that we can subscribe to
+// updates in each of the services that we support discovering and
+// monitoring.
+//
+///////////////////////////////////////////////////////////////////////////
+resource "google_pubsub_topic" "gcp_auditlog_sink" {
+  name = "chainguard-auditlogs"
+}
+
+// Allow our discovery identity to manage and consume subscriptions in the
+// project containing the topic and service accounts.
+// See also: https://groups.google.com/g/cloud-pubsub-discuss/c/DhfkLMWcRok
+resource "google_project_iam_custom_role" "create_auditlog_subscriptions" {
+  role_id     = "chainguardSubscriber"
+  title       = "Chainguard Subscriber"
+  description = "This role allows certain Chainguard roles to manage pub/sub subscriptions."
+  permissions = [
+    "pubsub.subscriptions.get",
+    "pubsub.subscriptions.create",
+    "pubsub.subscriptions.update",
+    "pubsub.subscriptions.delete",
+    "pubsub.subscriptions.consume",
+  ]
+}
+resource "google_project_iam_member" "discover_auditlog_subscriber" {
+  project = local.project_id
+  role    = "projects/${local.project_id}/roles/${google_project_iam_custom_role.create_auditlog_subscriptions.role_id}"
+  member  = "serviceAccount:${google_service_account.chainguard_discovery.email}"
+}
+resource "google_pubsub_topic_iam_member" "subscriber" {
+  project = google_pubsub_topic.gcp_auditlog_sink.project
+  topic   = google_pubsub_topic.gcp_auditlog_sink.name
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.chainguard_discovery.email}"
+}
+
+// Set up the logging sink to send auditlog events to the
+// pubsub topic.
+resource "google_logging_project_sink" "gcp_auditlog_sink" {
+  name = "chainguard-auditlogs"
+
+  // Send audit logs to the pubsub topic created above.
+  destination = "pubsub.googleapis.com/${google_pubsub_topic.gcp_auditlog_sink.id}"
+
+  // Create a unique service account for performing writes
+  // to the pubsub topic.
+  unique_writer_identity = true
+
+  // This determines the subset of the audit logs we receive.
+  filter = <<EOT
+LOG_ID("cloudaudit.googleapis.com/activity")
+protoPayload.serviceName = ("run.googleapis.com" OR "container.googleapis.com")
+EOT
+}
+
+// Attach a policy allowing the audit log sink's unique identity
+// to publish to the topic.
+resource "google_pubsub_topic_iam_member" "publisher" {
+  project = google_pubsub_topic.gcp_auditlog_sink.project
+  topic   = google_pubsub_topic.gcp_auditlog_sink.name
+  role    = "roles/pubsub.publisher"
+  member  = google_logging_project_sink.gcp_auditlog_sink.writer_identity
 }


### PR DESCRIPTION
:gift: This creates a pubsub topic audit log sink with a query covering the services we currently support, and expands the discovery identities capabilities to include managing subscriptions in the project that hosts the service account identities.

Ref: https://github.com/chainguard-dev/mono/issues/7382

/kind feature