### PR TITLE
Give enforce-signer the cloudkms.cryptoKeyVersions.get permission

### DIFF
--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -28,6 +28,7 @@ resource "google_project_iam_custom_role" "chainguard_signer_ca_role" {
     "cloudkms.cryptoKeyVersions.viewPublicKey",
     "cloudkms.cryptoKeyVersions.useToSign",
     "cloudkms.cryptoKeyVersions.list",
+    "cloudkms.cryptoKeyVersions.get",
   ]
 }
 


### PR DESCRIPTION
this is needed for KMS-based CAs which specify the cryptoKeyVersion on setup